### PR TITLE
OT260-15 The model, migrations and base controller of Organization were created

### DIFF
--- a/app/controllers/api/v1/organizations_controller.rb
+++ b/app/controllers/api/v1/organizations_controller.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+module Api
+  module V1
+    class OrganizationsController < ApplicationController
+    end
+  end
+end

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+# == Schema Information
+#
+# Table name: organizations
+#
+#  id            :bigint           not null, primary key
+#  about_us_text :text
+#  address       :string
+#  discarded_at  :datetime
+#  email         :string           not null
+#  name          :string           not null
+#  phone         :integer
+#  welcome_text  :text             not null
+#  created_at    :datetime         not null
+#  updated_at    :datetime         not null
+#
+# Indexes
+#
+#  index_organizations_on_discarded_at  (discarded_at)
+#
+class Organization < ApplicationRecord
+  include Discard::Model
+
+  has_one_attached :image
+
+  validates :name, :email, :welcome_text, presence: true
+  validates :phone, numericality: { only_integer: true }, allow_blank: true
+  validates :email, format: { with: /[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,6}/ }
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 Rails.application.routes.draw do
-  namespace :api, defaults: { format: 'json' } do
+  namespace :api, defaults: { format: :json } do
     namespace :v1 do
     end
   end

--- a/db/migrate/20220714124321_create_organizations.rb
+++ b/db/migrate/20220714124321_create_organizations.rb
@@ -1,0 +1,17 @@
+class CreateOrganizations < ActiveRecord::Migration[6.1]
+  def change
+    create_table :organizations do |t|
+      t.string :name, null: false
+      t.string :address
+      t.integer :phone
+      t.string :email, null: false
+      t.text :welcome_text, null: false
+      t.text :about_us_text
+
+      t.timestamps
+
+      t.datetime :discarded_at
+      t.index :discarded_at
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_07_14_120555) do
+ActiveRecord::Schema.define(version: 2022_07_14_124321) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -74,6 +74,19 @@ ActiveRecord::Schema.define(version: 2022_07_14_120555) do
     t.datetime "discarded_at"
     t.index ["category_id"], name: "index_news_on_category_id"
     t.index ["discarded_at"], name: "index_news_on_discarded_at"
+  end
+
+  create_table "organizations", force: :cascade do |t|
+    t.string "name", null: false
+    t.string "address"
+    t.integer "phone"
+    t.string "email", null: false
+    t.text "welcome_text", null: false
+    t.text "about_us_text"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.datetime "discarded_at"
+    t.index ["discarded_at"], name: "index_organizations_on_discarded_at"
   end
 
   create_table "roles", force: :cascade do |t|

--- a/spec/factories/organizations.rb
+++ b/spec/factories/organizations.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+# == Schema Information
+#
+# Table name: organizations
+#
+#  id            :bigint           not null, primary key
+#  about_us_text :text
+#  address       :string
+#  discarded_at  :datetime
+#  email         :string           not null
+#  name          :string           not null
+#  phone         :integer
+#  welcome_text  :text             not null
+#  created_at    :datetime         not null
+#  updated_at    :datetime         not null
+#
+# Indexes
+#
+#  index_organizations_on_discarded_at  (discarded_at)
+#
+FactoryBot.define do
+  factory :organization do
+    name { 'MyString' }
+    address { 'MyString' }
+    phone { 1 }
+    email { 'MyString' }
+    welcome_text { 'MyText' }
+    about_us_text { 'MyText' }
+  end
+end

--- a/spec/models/organization_spec.rb
+++ b/spec/models/organization_spec.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+# == Schema Information
+#
+# Table name: organizations
+#
+#  id            :bigint           not null, primary key
+#  about_us_text :text
+#  address       :string
+#  discarded_at  :datetime
+#  email         :string           not null
+#  name          :string           not null
+#  phone         :integer
+#  welcome_text  :text             not null
+#  created_at    :datetime         not null
+#  updated_at    :datetime         not null
+#
+# Indexes
+#
+#  index_organizations_on_discarded_at  (discarded_at)
+#
+require 'rails_helper'
+
+RSpec.describe Organization, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/requests/api/v1/organizations_spec.rb
+++ b/spec/requests/api/v1/organizations_spec.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Api::V1::Organizations', type: :request do
+  describe 'GET /index' do
+    pending "add some examples (or delete) #{__FILE__}"
+  end
+end


### PR DESCRIPTION
**The model, migrations and base controller of Organization were created**
There are two migrations, one for the Organization model and one for Discard softDeletes.
The fields of the model are:
1. The name which is a string and must exist to create a new organization.
2. The address which is a string and which need not exist to create a new organization.
3. The phone validates that it is a integer but it can be blank.
4. The email is a string and it has a format´s validation with regex. It can be blank.
5. The welcome_text is a text and must exist to create a new organization.
6. The about_us_text is a text and it´s need not exist to create a new organization.
7. It´s got a timestamps field which create automatically.
8. Discard was added in a second migration to apply softDeletes at the model.
9. The model allows to store an image.
Finally, the base controller was created without actions but even so the resources was created at routes.rb.
[Card OT260-15](https://alkemy-labs.atlassian.net/browse/OT260-15)