### PR TITLE
OT260-28 Crear migración y modelo de Slides

### DIFF
--- a/app/controllers/api/v1/categories_controller.rb
+++ b/app/controllers/api/v1/categories_controller.rb
@@ -3,6 +3,13 @@
 module Api
   module V1
     class CategoriesController < ApplicationController
+      before_action :authorization
+
+      # GET /category_id/public
+
+      def public
+        @category = Category.find(params[:id])
+      end
     end
   end
 end

--- a/app/controllers/api/v1/slides_controller.rb
+++ b/app/controllers/api/v1/slides_controller.rb
@@ -1,0 +1,2 @@
+class Api::V1::SlidesController < ApplicationController
+end

--- a/app/controllers/api/v1/slides_controller.rb
+++ b/app/controllers/api/v1/slides_controller.rb
@@ -1,2 +1,8 @@
-class Api::V1::SlidesController < ApplicationController
+# frozen_string_literal: true
+
+module Api
+  module V1
+    class SlidesController < ApplicationController
+    end
+  end
 end

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -22,8 +22,6 @@
 class Organization < ApplicationRecord
   include Discard::Model
 
-  has_one_attached :image
-
   validates :name, :email, :welcome_text, presence: true
   validates :phone, numericality: { only_integer: true }, allow_blank: true
   validates :email, format: { with: /[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,6}/ }

--- a/app/models/slide.rb
+++ b/app/models/slide.rb
@@ -1,0 +1,23 @@
+# == Schema Information
+#
+# Table name: slides
+#
+#  id              :bigint           not null, primary key
+#  image_url       :string
+#  order           :string
+#  text            :string
+#  created_at      :datetime         not null
+#  updated_at      :datetime         not null
+#  organization_id :bigint           not null
+#
+# Indexes
+#
+#  index_slides_on_organization_id  (organization_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (organization_id => organizations.id)
+#
+class Slide < ApplicationRecord
+  belongs_to :organization
+end

--- a/app/models/slide.rb
+++ b/app/models/slide.rb
@@ -1,11 +1,12 @@
+# frozen_string_literal: true
+
 # == Schema Information
 #
 # Table name: slides
 #
 #  id              :bigint           not null, primary key
-#  image_url       :string
-#  order           :string
-#  text            :string
+#  order           :integer          not null
+#  text            :text             not null
 #  created_at      :datetime         not null
 #  updated_at      :datetime         not null
 #  organization_id :bigint           not null

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,7 @@
 Rails.application.routes.draw do
   namespace :api, defaults: { format: :json } do
     namespace :v1 do
+      get 'id/public', to: 'categories#public'
     end
   end
 end

--- a/db/migrate/20220715183439_create_slides.rb
+++ b/db/migrate/20220715183439_create_slides.rb
@@ -1,9 +1,8 @@
 class CreateSlides < ActiveRecord::Migration[6.1]
   def change
     create_table :slides do |t|
-      t.string :image_url
-      t.string :text
-      t.string :order
+      t.text :text, null: false
+      t.integer :order, null: false
       t.references :organization, null: false, foreign_key: true
 
       t.timestamps

--- a/db/migrate/20220715183439_create_slides.rb
+++ b/db/migrate/20220715183439_create_slides.rb
@@ -1,0 +1,12 @@
+class CreateSlides < ActiveRecord::Migration[6.1]
+  def change
+    create_table :slides do |t|
+      t.string :image_url
+      t.string :text
+      t.string :order
+      t.references :organization, null: false, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -97,9 +97,8 @@ ActiveRecord::Schema.define(version: 2022_07_15_183439) do
   end
 
   create_table "slides", force: :cascade do |t|
-    t.string "image_url"
-    t.string "text"
-    t.string "order"
+    t.text "text", null: false
+    t.integer "order", null: false
     t.bigint "organization_id", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_07_14_124321) do
+ActiveRecord::Schema.define(version: 2022_07_15_183439) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -96,7 +96,18 @@ ActiveRecord::Schema.define(version: 2022_07_14_124321) do
     t.datetime "updated_at", precision: 6, null: false
   end
 
+  create_table "slides", force: :cascade do |t|
+    t.string "image_url"
+    t.string "text"
+    t.string "order"
+    t.bigint "organization_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["organization_id"], name: "index_slides_on_organization_id"
+  end
+
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
   add_foreign_key "news", "categories"
+  add_foreign_key "slides", "organizations"
 end

--- a/spec/factories/slides.rb
+++ b/spec/factories/slides.rb
@@ -1,11 +1,12 @@
+# frozen_string_literal: true
+
 # == Schema Information
 #
 # Table name: slides
 #
 #  id              :bigint           not null, primary key
-#  image_url       :string
-#  order           :string
-#  text            :string
+#  order           :integer          not null
+#  text            :text             not null
 #  created_at      :datetime         not null
 #  updated_at      :datetime         not null
 #  organization_id :bigint           not null
@@ -20,9 +21,9 @@
 #
 FactoryBot.define do
   factory :slide do
-    image_url { "MyString" }
-    text { "MyString" }
-    order { "MyString" }
+    image_url { 'MyString' }
+    text { 'MyString' }
+    order { 'MyString' }
     organization { nil }
   end
 end

--- a/spec/factories/slides.rb
+++ b/spec/factories/slides.rb
@@ -1,0 +1,28 @@
+# == Schema Information
+#
+# Table name: slides
+#
+#  id              :bigint           not null, primary key
+#  image_url       :string
+#  order           :string
+#  text            :string
+#  created_at      :datetime         not null
+#  updated_at      :datetime         not null
+#  organization_id :bigint           not null
+#
+# Indexes
+#
+#  index_slides_on_organization_id  (organization_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (organization_id => organizations.id)
+#
+FactoryBot.define do
+  factory :slide do
+    image_url { "MyString" }
+    text { "MyString" }
+    order { "MyString" }
+    organization { nil }
+  end
+end

--- a/spec/models/slide_spec.rb
+++ b/spec/models/slide_spec.rb
@@ -1,0 +1,25 @@
+# == Schema Information
+#
+# Table name: slides
+#
+#  id              :bigint           not null, primary key
+#  image_url       :string
+#  order           :string
+#  text            :string
+#  created_at      :datetime         not null
+#  updated_at      :datetime         not null
+#  organization_id :bigint           not null
+#
+# Indexes
+#
+#  index_slides_on_organization_id  (organization_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (organization_id => organizations.id)
+#
+require 'rails_helper'
+
+RSpec.describe Slide, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/slide_spec.rb
+++ b/spec/models/slide_spec.rb
@@ -1,11 +1,12 @@
+# frozen_string_literal: true
+
 # == Schema Information
 #
 # Table name: slides
 #
 #  id              :bigint           not null, primary key
-#  image_url       :string
-#  order           :string
-#  text            :string
+#  order           :integer          not null
+#  text            :text             not null
 #  created_at      :datetime         not null
 #  updated_at      :datetime         not null
 #  organization_id :bigint           not null

--- a/spec/requests/api/v1/slides_spec.rb
+++ b/spec/requests/api/v1/slides_spec.rb
@@ -1,0 +1,7 @@
+require 'rails_helper'
+
+RSpec.describe "Api::V1::Slides", type: :request do
+  describe "GET /index" do
+    pending "add some examples (or delete) #{__FILE__}"
+  end
+end

--- a/spec/requests/api/v1/slides_spec.rb
+++ b/spec/requests/api/v1/slides_spec.rb
@@ -1,7 +1,9 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
-RSpec.describe "Api::V1::Slides", type: :request do
-  describe "GET /index" do
+RSpec.describe 'Api::V1::Slides', type: :request do
+  describe 'GET /index' do
     pending "add some examples (or delete) #{__FILE__}"
   end
 end


### PR DESCRIPTION
Se crea nuevamente el modelo Slides con organization_id incluido y controlador el la api correspondiente

Comandos utilizados:
rails g model Slide image_url text order organization:references
rails g controller Api::V1::Slides
rails db:reset
bin/rails db:migrate

