### PR TITLE
feat/OT260-35-Endpoint para listar Usuarios

### DIFF
--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -6,7 +6,13 @@ module Api
   module V1
     class UsersController < ApplicationController
       before_action :set_user, only: :login
-      before_action :authenticate_request, only: :me
+      before_action :authenticate_request, only: %i[index me create]
+      before_action :authorize_user, only: %i[index me create]
+
+      def index
+        @users = User.kept
+        render json: UserSerializer.new(@users).serializable_hash.to_json
+      end
 
       def me
         render json: UserSerializer.new(@current_user).serializable_hash, status: :ok

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,6 +10,7 @@ Rails.application.routes.draw do
         get 'public', on: :member
       end
       resources :news, only: %i[show create]
+      resources :users, only: [:index]
     end
   end
   


### PR DESCRIPTION
COMO usuario administrador
QUIERO visualizar un listado de Usuarios
PARA mantener un seguimiento de quiénes forman parte del sistema

Criterios de aceptación:
GET a /users . Devolverá un listado de todos los Usuarios. Este endpoint solo deberá ser accesible por los Usuarios administradores.