### PR TITLE
OT260-45 News' data show Endpoint

### DIFF
--- a/app/controllers/api/v1/news_controller.rb
+++ b/app/controllers/api/v1/news_controller.rb
@@ -3,14 +3,19 @@
 module Api
   module V1
     class NewsController < ApplicationController
-      before_action :authenticate_request, only: %i[create]
-      before_action :authorize_user, only: %i[create]
+      before_action :set_news, only: %i[show]
+      before_action :authenticate_request, only: %i[show create]
+      before_action :authorize_user, only: %i[show create]
+
+      def show
+        render json: NewsSerializer.new(@news).serializable_hash
+      end
 
       def create
         @news = News.new(news_params)
         @news.category = Category.find(params[:news][:category_id])
         if @news.save
-          render json: NewsSerializer.new(@news).serializable_hash.to_json,
+          render json: NewsSerializer.new(@news).serializable_hash,
                  status: :created
         else
           render json: { errors: @news }, status: :unprocessable_entity
@@ -18,6 +23,12 @@ module Api
       end
 
       private
+
+      def set_news
+        @news = News.find(params[:id])
+      rescue ActiveRecord::RecordNotFound
+        render json: { error: "Could not find news with ID '#{params[:id]}'" }
+      end
 
       def news_params
         params.require(:news).permit(:content, :image, :name, :news_type)

--- a/app/serializers/news_serializer.rb
+++ b/app/serializers/news_serializer.rb
@@ -26,5 +26,14 @@
 class NewsSerializer
   include JSONAPI::Serializer
   attributes :content, :name, :image
+
+  attribute :image do |news|
+    if news.image.attached?
+      Rails.application
+           .routes
+           .url_helpers.rails_blob_path(news.image, only_path: true)
+    end
+  end
+
   belongs_to :category
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,7 +9,7 @@ Rails.application.routes.draw do
       resources :organizations, only: [] do
         get 'public', on: :member
       end
-      resources :news, only: [:create]
+      resources :news, only: %i[show create]
     end
   end
   


### PR DESCRIPTION
COMO usuario administrador
QUIERO ver los detalles de una novedad
PARA poder informar actualizaciones del contenido

Criterios de aceptación:
GET a /news/:id . Mostrará todos los campos de una entry en base al id enviado por parámetro.