### PR TITLE
OT260-49  News delete data  Endpoint

### DIFF
--- a/app/controllers/api/v1/news_controller.rb
+++ b/app/controllers/api/v1/news_controller.rb
@@ -3,9 +3,9 @@
 module Api
   module V1
     class NewsController < ApplicationController
-      before_action :set_news, only: %i[show update]
-      before_action :authenticate_request, only: %i[show create update]
-      before_action :authorize_user, only: %i[show create update]
+      before_action :set_news, only: %i[show update destroy]
+      before_action :authenticate_request, only: %i[show create update destroy]
+      before_action :authorize_user, only: %i[show create update destroy]
 
       def show
         render json: NewsSerializer.new(@news).serializable_hash
@@ -23,6 +23,11 @@ module Api
       def update
         @news.update(news_params)
         render json: NewsSerializer.new(@news).serializable_hash
+      end
+
+      def destroy
+        @news.discard
+        head :no_content
       end
 
       private

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,7 +9,7 @@ Rails.application.routes.draw do
       resources :organizations, only: [] do
         get 'public', on: :member
       end
-      resources :news, only: %i[show create update]
+      resources :news, only: %i[show create update destroy]
       resources :users, only: [:index]
     end
   end


### PR DESCRIPTION
COMO usuario administrador
QUIERO eliminar una actividad existente
PARA mantener la información actualizada

Criterios de aceptación:
DELETE /news/:id - Deberá validar la existencia en base al id enviado por parámetro. En el caso de que exista, eliminarla