### PR TITLE
OT260-33Middleware-de-Ownership

### DIFF
--- a/app/controllers/concerns/authorization.rb
+++ b/app/controllers/concerns/authorization.rb
@@ -17,3 +17,4 @@ module Authorization
     render json: { errors: 'Unauthorized access' }, status: :forbidden unless admin? || owner?
   end
 end
+

--- a/app/controllers/concerns/authorization.rb
+++ b/app/controllers/concerns/authorization.rb
@@ -17,4 +17,3 @@ module Authorization
     render json: { errors: 'Unauthorized access' }, status: :forbidden unless admin? || owner?
   end
 end
-

--- a/app/controllers/concerns/authorization.rb
+++ b/app/controllers/concerns/authorization.rb
@@ -8,4 +8,12 @@ module Authorization
   def admin?
     @current_user.role.name == 'administrator'
   end
+
+  def owner?
+    params[:id].to_i == @current_user.id
+  end
+
+  def ownership?
+    render json: { errors: 'Unauthorized access' }, status: :forbidden unless admin? || owner?
+  end
 end


### PR DESCRIPTION
Middleware de Ownership

COMO usuario
QUIERO acceder únicamente a las secciones permitidas para mi rol
PARA completar ciertas acciones

Criterios de aceptación:
Se utilizará para proteger endpoints que son solo para el usuario actual. Deberá verificar el parámetro id y compararlo con el ID del usuario enviado en el token JWT, caso contrario, devolver error 403. Sin embargo, si el usuario que es enviado en el token es administrador, si le permitirá continuar