### PR TITLE
OT260-50 Return token to the user after registering on the site

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -24,6 +24,14 @@ Metrics/BlockLength:
     - config/**/*
     - spec/**/*
 
+Metrics/AbcSize:
+  Exclude:
+    - app/controllers/api/v1/authentication_controller.rb
+
+Lint/DuplicateBranch:
+  Exclude:
+    - app/controllers/application_controller.rb 
+
 Lint/AmbiguousBlockAssociation:
   Exclude:
     - spec/**/*

--- a/app/controllers/api/v1/authentication_controller.rb
+++ b/app/controllers/api/v1/authentication_controller.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require 'json_web_token'
+
+module Api
+  module V1
+    class AuthenticationController < ApplicationController
+      before_action :authorize_request, except: :login
+
+      def login
+        @user = User.find_by(email: params[:email])
+        if @user&.authenticate(params[:password_digest])
+          token = JsonWebToken.encode(user_id: @user.id)
+          time = Time.zone.now + 24.hours.to_i
+          render json: { token: token, exp: time.strftime('%m-%d-%Y %H:%M'),
+                         username: @user.first_name }, status: :ok
+        else
+          render json: { error: 'unauthorized' }, status: :unauthorized
+        end
+      end
+
+      private
+
+      def login_params
+        params.permit(:email, :password_digest)
+      end
+    end
+  end
+end

--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -3,6 +3,7 @@
 module Api
   module V1
     class UsersController < ApplicationController
+      before_action :authorize_request, except: :create
     end
   end
 end

--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -5,9 +5,8 @@ require 'json_web_token'
 module Api
   module V1
     class UsersController < ApplicationController
-<<<<<<< HEAD
       before_action :authorize_request, except: :create
-=======
+
       def create
         @user = User.new(user_params)
         if @user.save
@@ -32,7 +31,6 @@ module Api
         render json: { errors: @user.errors.full_messages },
                status: :unprocessable_entity
       end
->>>>>>> OT260-50 Return token to the user after registering on the site
     end
   end
 end

--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -1,9 +1,38 @@
 # frozen_string_literal: true
 
+require 'json_web_token'
+
 module Api
   module V1
     class UsersController < ApplicationController
+<<<<<<< HEAD
       before_action :authorize_request, except: :create
+=======
+      def create
+        @user = User.new(user_params)
+        if @user.save
+          token = JsonWebToken.encode(user_id: @user)
+          render json: {
+            user: UserSerializer.new(@user).serializable_hash,
+            token: token
+          }, status: :created
+        else
+          render_error
+        end
+      end
+
+      private
+
+      def user_params
+        params.require(:user).permit(:first_name, :last_name, :email, :password, :photo,
+                                     :role_id)
+      end
+
+      def render_error
+        render json: { errors: @user.errors.full_messages },
+               status: :unprocessable_entity
+      end
+>>>>>>> OT260-50 Return token to the user after registering on the site
     end
   end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,4 +2,17 @@
 
 class ApplicationController < ActionController::API
   include Authorization
+
+  def authorize_request
+    header = request.headers['Authorization']
+    header = header.split.last if header
+    begin
+      @decoded = JsonWebToken.decode(header)
+      @current_user = User.find(@decoded[:user_id])
+    rescue ActiveRecord::RecordNotFound => e
+      render json: { errors: e.message }, status: :unauthorized
+    rescue JWT::DecodeError => e
+      render json: { errors: e.message }, status: :unauthorized
+    end
+  end
 end

--- a/app/controllers/concerns/authorization.rb
+++ b/app/controllers/concerns/authorization.rb
@@ -8,4 +8,12 @@ module Authorization
   def admin?
     @current_user.role.name == 'administrator'
   end
+
+  def owner?
+    params[:id].to_i == @current_user.id
+  end
+
+  def ownership?
+    render json: { errors: 'Unauthorized access' }, status: :forbidden unless admin? || owner?
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -9,7 +9,7 @@
 #  email        :string           not null
 #  first_name   :string           not null
 #  last_name    :string           not null
-#  password     :string           not null
+#  password_digest     :string           not null
 #  photo        :string
 #  created_at   :datetime         not null
 #  updated_at   :datetime         not null
@@ -27,9 +27,10 @@
 #
 class User < ApplicationRecord
   include Discard::Model
+  has_secure_password
 
   belongs_to :role
 
-  validates :first_name, :last_name, :email, :password, presence: true
+  validates :first_name, :last_name, :email, :password_digest, presence: true
   validates :email, uniqueness: true
 end

--- a/app/serializers/user_serializer.rb
+++ b/app/serializers/user_serializer.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+class UserSerializer
+  include JSONAPI::Serializer
+  attributes :first_name, :last_name, :email, :photo
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,8 @@
 Rails.application.routes.draw do
   namespace :api, defaults: { format: :json } do
     namespace :v1 do
+      post "auth/login", to: "authentication#login"
+      post "auth/register", to: "users#create"
     end
   end
 end

--- a/lib/json_web_token.rb
+++ b/lib/json_web_token.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+class JsonWebToken
+  SECRET_KEY = Rails.application.secrets.secret_key_base.to_s
+
+  def self.encode(payload, exp = 24.hours.from_now)
+    payload[:exp] = exp.to_i
+    JWT.encode(payload, SECRET_KEY)
+  end
+
+  def self.decode(token)
+    decoded = JWT.decode(token, SECRET_KEY)[0]
+    HashWithIndifferentAccess.new decoded
+  end
+end

--- a/spec/requests/api/v1/authentication_spec.rb
+++ b/spec/requests/api/v1/authentication_spec.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Api::V1::Authentications', type: :request do
+  describe 'GET /index' do
+    pending "add some examples (or delete) #{__FILE__}"
+  end
+end


### PR DESCRIPTION
As a authenticated user I can get an authetication token to keep me logged into the app.
The user registration endpoint was modified to get the token associated with the new user as a response allowing it to be stored on the customer side.
![image](https://user-images.githubusercontent.com/65079282/180325027-39cfb8d3-bf34-43d0-a435-5f7f136bffa7.png)
In case the new user registration cannot be saved in the database for errors in the entry of the data, a message is displayed detailing the errors for their suitability.
![image](https://user-images.githubusercontent.com/65079282/180325365-54a0f439-073b-45c9-8ce0-c5d3c83c1e01.png)
[Ticket 260-50](https://alkemy-labs.atlassian.net/browse/OT260-50)