### PR TITLE
feat/OT260-84 News Pagination with Pagy

### DIFF
--- a/app/controllers/api/v1/news_controller.rb
+++ b/app/controllers/api/v1/news_controller.rb
@@ -6,9 +6,16 @@ module Api
       before_action :set_news, only: %i[show update destroy]
       before_action :authenticate_request, only: %i[show create update destroy]
       before_action :authorize_user, only: %i[show create update destroy]
+      after_action { pagy_headers_merge(@pagy) if @pagy }
+      include Pagy::Backend
+
+      def index
+        @pagy, @news = pagy(Category.kept)
+        render json: NewsSerializer.new(@news).serializable_hash, status: :ok
+      end
 
       def show
-        render json: NewsSerializer.new(@news).serializable_hash
+        render json: NewsSerializer.new(@news).serializable_hash, status: :ok
       end
 
       def create
@@ -22,7 +29,7 @@ module Api
 
       def update
         @news.update(news_params)
-        render json: NewsSerializer.new(@news).serializable_hash
+        render json: NewsSerializer.new(@news).serializable_hash, status: :ok
       end
 
       def destroy

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,7 +10,7 @@ Rails.application.routes.draw do
       resources :categories, only: %i[index create show update destroy]
       resources :comments, only: %i[index create update]
       resources :members, only: %i[index create update destroy]
-      resources :news, only: %i[show create update destroy]
+      resources :news, only: %i[index show create update destroy]
       resources :activities, only: %i[create update]
       resources :organizations, only: [] do
         get 'public', on: :member


### PR DESCRIPTION
COMO usuario
QUIERO visualizar los resultados de Novedades paginados
PARA aumentar la velocidad de respuesta

Criterios de aceptación:

Cuando se realice la petición para listar, los resultados deberán paginarse de a 10. En la respuesta, se deberán mostrar los resultados y las urls para la página anterior y siguiente (si corresponden). La página actual se obtendrá del parámetro de query ?page