### PR TITLE
feat/OT260-85 Members Pagination with Pagy

### DIFF
--- a/app/controllers/api/v1/members_controller.rb
+++ b/app/controllers/api/v1/members_controller.rb
@@ -6,9 +6,11 @@ module Api
       before_action :authenticate_request, only: %i[index create update destroy]
       before_action :authorize_user, only: %i[index]
       before_action :set_member, only: %i[update destroy]
+      after_action { pagy_headers_merge(@pagy) if @pagy }
+      include Pagy::Backend
 
       def index
-        @members = Member.kept
+        @pagy, @members = pagy(Member.kept)
         render json: MembersSerializer.new(@members).serializable_hash, status: :ok
       end
 


### PR DESCRIPTION
COMO usuario
QUIERO visualizar los resultados de Miembros paginados
PARA aumentar la velocidad de respuesta

Criterios de aceptación:
Cuando se realice la petición para listar, los resultados deberán paginarse de a 10. En la respuesta, se deberán mostrar los resultados y las urls para la página anterior y siguiente (si corresponden). La página actual se obtendrá del parámetro de query ?page