### PR TITLE
feat/OT260-64 Agregar campos de contacto a organizations

### DIFF
--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -9,6 +9,9 @@
 #  address       :string
 #  discarded_at  :datetime
 #  email         :string           not null
+#  facebook_url  :string
+#  instagram_url :string
+#  linkedin_url  :string
 #  name          :string           not null
 #  phone         :integer
 #  welcome_text  :text             not null

--- a/app/serializers/organization_serializer.rb
+++ b/app/serializers/organization_serializer.rb
@@ -9,6 +9,9 @@
 #  address       :string
 #  discarded_at  :datetime
 #  email         :string           not null
+#  facebook_url  :string
+#  instagram_url :string
+#  linkedin_url  :string
 #  name          :string           not null
 #  phone         :integer
 #  welcome_text  :text             not null

--- a/db/migrate/20220722143207_add_contact_to_organizations.rb
+++ b/db/migrate/20220722143207_add_contact_to_organizations.rb
@@ -1,0 +1,7 @@
+class AddContactToOrganizations < ActiveRecord::Migration[6.1]
+  def change
+    add_column :organizations, :facebook_url, :string
+    add_column :organizations, :instagram_url, :string
+    add_column :organizations, :linkedin_url, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -106,6 +106,9 @@ ActiveRecord::Schema.define(version: 2022_07_25_135239) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.datetime "discarded_at"
+    t.string "facebook_url"
+    t.string "instagram_url"
+    t.string "linkedin_url"
     t.index ["discarded_at"], name: "index_organizations_on_discarded_at"
   end
 

--- a/spec/factories/organizations.rb
+++ b/spec/factories/organizations.rb
@@ -9,6 +9,9 @@
 #  address       :string
 #  discarded_at  :datetime
 #  email         :string           not null
+#  facebook_url  :string
+#  instagram_url :string
+#  linkedin_url  :string
 #  name          :string           not null
 #  phone         :integer
 #  welcome_text  :text             not null

--- a/spec/models/organization_spec.rb
+++ b/spec/models/organization_spec.rb
@@ -9,6 +9,9 @@
 #  address       :string
 #  discarded_at  :datetime
 #  email         :string           not null
+#  facebook_url  :string
+#  instagram_url :string
+#  linkedin_url  :string
 #  name          :string           not null
 #  phone         :integer
 #  welcome_text  :text             not null


### PR DESCRIPTION
COMO usuario administrador
QUIERO editar los campos de contacto a la Organización
PARA mostrar la información de la mejor manera posible. 

Criterios de aceptación:
Crear una migración para agregar las urls de redes sociales a una Organización. Se deberán agregar url de Facebook, Linkedin e Instagram