### PR TITLE
OT260-56 List of slides Endpoint

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -17,7 +17,7 @@ AllCops:
     - testing/vendor/**/*
 
 Layout/LineLength:
-  Max: 100
+  Max: 105
 
 Metrics/AbcSize:
   Exclude:

--- a/app/controllers/api/v1/slides_controller.rb
+++ b/app/controllers/api/v1/slides_controller.rb
@@ -3,9 +3,18 @@
 module Api
   module V1
     class SlidesController < ApplicationController
-      before_action :authenticate_request, only: %i[show create update destroy]
-      before_action :authorize_user, only: %i[show create update destroy]
+      before_action :authenticate_request, only: %i[index show create update destroy]
+      before_action :authorize_user, only: %i[index show create update destroy]
       before_action :set_slide, only: %i[show update destroy]
+
+      def index
+        @slides = Slide.all
+        render json: SlideSerializer.new(@slides,
+                                         { fields: {
+                                           slide: %i[image order]
+                                         } })
+                                    .serializable_hash, status: :ok
+      end
 
       def show
         if @slide

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -15,7 +15,7 @@ Rails.application.routes.draw do
       resources :organizations, only: [] do
         get 'public', on: :member
       end
-      resources :slides, only: %i[show create update destroy]
+      resources :slides, only: %i[index show create update destroy]
       resources :users, only: %i[index update destroy]
     end
   end


### PR DESCRIPTION
As an administrator user I can see the list of slides to see the content graphically.
The list of Slides is returned, with the thumbnail and the order of each Slide in a json.
![image](https://user-images.githubusercontent.com/65079282/180582579-41d06c50-4ef7-4a61-a197-be044f41c052.png)

[Ticket OT260-56](https://alkemy-labs.atlassian.net/browse/OT260-56)