### PR TITLE
OT260-67Endpoint-Creación-Testimonios

### DIFF
--- a/app/controllers/api/v1/testimonials_controller.rb
+++ b/app/controllers/api/v1/testimonials_controller.rb
@@ -3,6 +3,23 @@
 module Api
   module V1
     class TestimonialsController < ApplicationController
+      before_action :authenticate_request, only: %i[create]
+      before_action :authorize_user, only: %i[create]
+
+      def create
+        @testimonial = Testimonial.new(testimonial_params)
+        if @testimonial.save
+          render json: TestimonialSerializer.new(@testimonial).serializable_hash, status: :created
+        else
+          render json: @testimonial.errors, status: :unprocessable_entity
+        end
+      end
+
+      private
+
+      def testimonial_params
+        params.require(:testimonial).permit(:image, :name, :content)
+      end
     end
   end
 end

--- a/app/serializers/testimonial_serializer.rb
+++ b/app/serializers/testimonial_serializer.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class TestimonialSerializer
+  include JSONAPI::Serializer
+  attributes :name, :content
+  attribute :image do |object|
+    object.image.url if object.image.filename
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -16,6 +16,7 @@ Rails.application.routes.draw do
         get 'public', on: :member
       end
       resources :slides, only: %i[index show create update destroy]
+      resources :testimonials, only: %i[create]
       resources :users, only: %i[index update destroy]
     end
   end


### PR DESCRIPTION
Endpoint Creación Testimonios
COMO usuario administrador
QUIERO dar de alta nuevos Testimonios
PARA informar Novedades acerca de la ONG.

Criterios de aceptación:
POST /testimonials - Deberá validar la existencia de los campos name y content enviados, para almacenar el registro en la tabla testimonials.