### PR TITLE
OT260-69Endpoint-eliminación-de-Testimonios

### DIFF
--- a/app/controllers/api/v1/testimonials_controller.rb
+++ b/app/controllers/api/v1/testimonials_controller.rb
@@ -3,9 +3,9 @@
 module Api
   module V1
     class TestimonialsController < ApplicationController
-      before_action :authenticate_request, only: %i[create update]
-      before_action :authorize_user, only: %i[create update]
-      before_action :set_testimonial, only: %i[update]
+      before_action :authenticate_request, only: %i[create update destroy]
+      before_action :authorize_user, only: %i[create update destroy]
+      before_action :set_testimonial, only: %i[update destroy]
 
       def create
         @testimonial = Testimonial.new(testimonial_params)
@@ -20,6 +20,11 @@ module Api
         else
           render json: @testimonial.errors, status: :unprocessable_entity
         end
+      end
+
+      def destroy
+        @testimonial.discard
+        head :no_content
       end
 
       private

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -16,7 +16,7 @@ Rails.application.routes.draw do
         get 'public', on: :member
       end
       resources :slides, only: %i[index show create update destroy]
-      resources :testimonials, only: %i[create update]
+      resources :testimonials, only: %i[create update destroy]
       resources :users, only: %i[index update destroy]
     end
   end


### PR DESCRIPTION
Endpoint eliminación de Testimonios
COMO usuario administrador
QUIERO eliminar Testimonios
PARA moderar los Testimonios y Novedades acerca de la ONG.

Criterios de aceptación:
Cuando el usuario se registre en el sitio, deberá loguearse automáticamente y redirigirse a la ruta base:check_mark:. Para ello, es necesario modificar el servidor para que devuelva el token una vez creado el usuario, y almacenar el mismo en el lado del cliente