### PR TITLE
OT260-57 Endpoint Slides Details

### DIFF
--- a/app/controllers/api/v1/slides_controller.rb
+++ b/app/controllers/api/v1/slides_controller.rb
@@ -3,9 +3,17 @@
 module Api
   module V1
     class SlidesController < ApplicationController
-      before_action :authenticate_request, only: %i[create update destroy]
-      before_action :authorize_user, only: %i[create update destroy]
-      before_action :set_slide, only: %i[update destroy]
+      before_action :authenticate_request, only: %i[show create update destroy]
+      before_action :authorize_user, only: %i[show create update destroy]
+      before_action :set_slide, only: %i[show update destroy]
+
+      def show
+        if @slide
+          render json: SlideSerializer.new(@slide).serializable_hash.to_json, status: :ok
+        else
+          render_error
+        end
+      end
 
       def create
         @slide = Slide.new(slide_params)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,7 +14,7 @@ Rails.application.routes.draw do
       resources :organizations, only: [] do
         get 'public', on: :member
       end
-      resources :slides, only: %i[create update destroy]
+      resources :slides, only: %i[show create update destroy]
       resources :users, only: %i[index update destroy]
     end
   end


### PR DESCRIPTION
As a administrator user I want to see the slides´s details to see the content in more detail.
You can see the information of each slide and in case there is no slide asociated to the id that is queried returns error 404: not found
![image](https://user-images.githubusercontent.com/65079282/181387842-94a941ee-bcc6-45b3-8310-fcfe644ca3a8.png)
![image](https://user-images.githubusercontent.com/65079282/181387867-c1921c25-ad23-4b1e-b21e-0ac5c3c72fcf.png)
[OT260-57](https://alkemy-labs.atlassian.net/browse/OT260-57)