### PR TITLE
OT260-65Modificar-endpoint-público-de-organizations-para-devolver-lin…

### DIFF
--- a/app/controllers/api/v1/organizations_controller.rb
+++ b/app/controllers/api/v1/organizations_controller.rb
@@ -14,6 +14,9 @@ module Api
                                                   image
                                                   phone
                                                   address
+                                                  facebook_url
+                                                  instagram_url
+                                                  linkedin_url
                                                 ] })
                                            .serializable_hash, status: :ok
       end

--- a/app/serializers/organization_serializer.rb
+++ b/app/serializers/organization_serializer.rb
@@ -25,4 +25,5 @@
 class OrganizationSerializer
   include JSONAPI::Serializer
   attributes :name, :address, :email, :phone, :welcome_text, :about_us_text
+  attributes :facebook_url, :linkedin_url, :instagram_url
 end


### PR DESCRIPTION
Modificar endpoint público de organizations para devolver links de redes sociales
COMO usuario
QUIERO ver los links de las redes sociales al entrar a la página
PARA poder acceder a ellas.

Criterios de aceptación:

Al devolver los datos en el endpoint de datos públicos, agregar los campos de redes sociales en la respuesta