### PR TITLE
feat/OT-260-96-add-members-testing

### DIFF
--- a/app/controllers/api/v1/members_controller.rb
+++ b/app/controllers/api/v1/members_controller.rb
@@ -15,7 +15,7 @@ module Api
       end
 
       def create
-        if category_params[:name].to_i.to_s == '0'
+        if member_params[:name].to_i.to_s == '0'
           @member = Member.new(member_params)
           if @member.save
             render json: MemberSerializer.new(@member).serializable_hash, status: :created
@@ -28,8 +28,12 @@ module Api
       end
 
       def update
-        if @member.update(member_params)
-          render json: MemberSerializer.new(@member).serializable_hash, status: :ok
+        if member_params[:name].to_i.to_s == '0'
+          if @member.update(member_params)
+            render json: MemberSerializer.new(@member).serializable_hash, status: :ok
+          else
+            render json: @member.errors, status: :unprocessable_entity
+          end
         else
           render json: @member.errors, status: :unprocessable_entity
         end

--- a/spec/factories/members.rb
+++ b/spec/factories/members.rb
@@ -20,10 +20,10 @@
 #
 FactoryBot.define do
   factory :member do
-    name { 'MyString' }
-    facebook_url { 'MyString' }
-    instagram_url { 'MyString' }
-    linkedin_url { 'MyString' }
-    description { 'MyString' }
+    name { Faker::Name.first_name }
+    facebook_url { Faker::Internet.url(host: 'facebook.com') }
+    instagram_url { Faker::Internet.url(host: 'instagram.com') }
+    linkedin_url { Faker::Internet.url(host: 'linkedin.com') }
+    description { Faker::Lorem.paragraph }
   end
 end

--- a/spec/models/member_spec.rb
+++ b/spec/models/member_spec.rb
@@ -18,8 +18,34 @@
 #
 #  index_members_on_discarded_at  (discarded_at)
 #
+
 require 'rails_helper'
 
 RSpec.describe Member, type: :model do
   pending "add some examples to (or delete) #{__FILE__}"
+  subject { create(:member) }
+
+  describe 'Factory' do
+    it { is_expected.to be_valid }
+  end
+
+  describe 'Validations' do
+    it { is_expected.to validate_presence_of(:name) }
+  end
+
+  describe 'Database' do
+    it { is_expected.to have_db_column(:id).of_type(:integer).with_options(null: false) }
+    it { is_expected.to have_db_column(:description).of_type(:string) }
+    it { is_expected.to have_db_column(:discarded_at).of_type(:datetime) }
+    it { is_expected.to have_db_column(:facebook_url).of_type(:string) }
+    it { is_expected.to have_db_column(:instagram_url).of_type(:string) }
+    it { is_expected.to have_db_column(:linkedin_url).of_type(:string) }
+    it { is_expected.to have_db_column(:name).of_type(:string).with_options(null: false) }
+    it { is_expected.to have_db_column(:created_at).of_type(:datetime).with_options(null: false) }
+    it { is_expected.to have_db_column(:updated_at).of_type(:datetime).with_options(null: false) }
+  end
+
+  describe 'Indexes' do
+    it { is_expected.to have_db_index(:discarded_at) }
+  end
 end

--- a/spec/models/role_spec.rb
+++ b/spec/models/role_spec.rb
@@ -10,8 +10,30 @@
 #  created_at  :datetime         not null
 #  updated_at  :datetime         not null
 #
+
 require 'rails_helper'
 
 RSpec.describe Role, type: :model do
   pending "add some examples to (or delete) #{__FILE__}"
+  subject { create(:role) }
+
+  describe 'Factory' do
+    it { is_expected.to be_valid }
+  end
+
+  describe 'Validations' do
+    it { is_expected.to validate_presence_of(:name) }
+  end
+
+  describe 'Associations' do
+    it { is_expected.to have_many(:users) }
+  end
+
+  describe 'Database' do
+    it { is_expected.to have_db_column(:id).of_type(:integer).with_options(null: false) }
+    it { is_expected.to have_db_column(:description).of_type(:string) }
+    it { is_expected.to have_db_column(:name).of_type(:string).with_options(null: false) }
+    it { is_expected.to have_db_column(:created_at).of_type(:datetime).with_options(null: false) }
+    it { is_expected.to have_db_column(:updated_at).of_type(:datetime).with_options(null: false) }
+  end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -28,4 +28,42 @@ require 'rails_helper'
 
 RSpec.describe User, type: :model do
   pending "add some examples to (or delete) #{__FILE__}"
+  subject { create(:user) }
+
+  describe 'Factory' do
+    it { is_expected.to be_valid }
+  end
+
+  describe 'Validations' do
+    it { is_expected.to validate_presence_of(:email) }
+    it { is_expected.to validate_uniqueness_of(:email) }
+    it { is_expected.to validate_presence_of(:first_name) }
+    it { is_expected.to validate_presence_of(:last_name) }
+    it { is_expected.to validate_presence_of(:password) }
+  end
+
+  describe 'Associations' do
+    it { is_expected.to have_many(:comments) }
+    it { is_expected.to have_many(:contacts) }
+
+    it { is_expected.to belong_to(:role) }
+  end
+
+  describe 'Database' do
+    it { is_expected.to have_db_column(:id).of_type(:integer).with_options(null: false) }
+    it { is_expected.to have_db_column(:discarded_at).of_type(:datetime) }
+    it { is_expected.to have_db_column(:email).of_type(:string).with_options(null: false) }
+    it { is_expected.to have_db_column(:first_name).of_type(:string).with_options(null: false) }
+    it { is_expected.to have_db_column(:last_name).of_type(:string).with_options(null: false) }
+    it { is_expected.to have_db_column(:password_digest).of_type(:string) }
+    it { is_expected.to have_db_column(:created_at).of_type(:datetime).with_options(null: false) }
+    it { is_expected.to have_db_column(:updated_at).of_type(:datetime).with_options(null: false) }
+    it { is_expected.to have_db_column(:role_id).of_type(:integer).with_options(null: false) }
+  end
+
+  describe 'Indexes' do
+    it { is_expected.to have_db_index(:discarded_at) }
+    it { is_expected.to have_db_index(:email) }
+    it { is_expected.to have_db_index(:role_id) }
+  end
 end

--- a/spec/requests/api/v1/members_spec.rb
+++ b/spec/requests/api/v1/members_spec.rb
@@ -3,7 +3,112 @@
 require 'rails_helper'
 
 RSpec.describe 'Api::V1::Members', type: :request do
+  before do
+    ENV['JWT_SECRET_KEY'] = 'secret_key'
+  end
+
+  let(:login_user) do
+    create(:user, password: 'password')
+    post api_v1_auth_login_path,
+         params: { user: { email: User.last.email, password: 'password' } }, as: :json
+    JSON.parse(response.body, symbolize_names: true)
+  end
+
+  let(:valid_headers) { { Authorization: login_user[:token] } }
+
+  let(:valid_attributes) { build(:member) }
+
+  let(:invalid_attributes) { build(:member, name: 123_456) }
+
   describe 'GET /index' do
-    pending "add some examples (or delete) #{__FILE__}"
+    before { create_list :member, 3 }
+
+    it 'renders a successful response' do
+      get api_v1_members_path, headers: valid_headers, as: :json
+      expect(response).to be_successful
+    end
+
+    it 'renders three registers from database' do
+      get api_v1_members_path, headers: valid_headers, as: :json
+      response_hash = JSON.parse(response.body, symbolize_names: true)
+      expect(response_hash[:data].size).to eq(Member.all.size)
+    end
+  end
+
+  describe 'POST /create' do
+    context 'with valid parameters' do
+      it 'creates a new member' do
+        expect do
+          post api_v1_members_path, params: valid_attributes, headers: valid_headers, as: :json
+        end.to change(Member, :count).by(1)
+      end
+
+      it 'renders a JSON response with the new member' do
+        post api_v1_members_path,
+             params: valid_attributes, headers: valid_headers, as: :json
+        expect(response).to have_http_status(:created)
+        expect(response.content_type).to match(a_string_including('application/json; charset=utf-8'))
+      end
+    end
+
+    context 'with invalid parameters' do
+      it 'does not create a new member' do
+        expect do
+          post api_v1_members_path,
+               params: { member: invalid_attributes }, as: :json
+        end.not_to change(Member, :count)
+      end
+
+      it 'renders a JSON response with errors for the new member' do
+        post api_v1_members_path,
+             params: { member: invalid_attributes }, headers: valid_headers, as: :json
+        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response.content_type).to eq('application/json; charset=utf-8')
+      end
+    end
+  end
+
+  describe 'PUT /update' do
+    context 'with valid parameters' do
+      let(:new_attributes) do
+        build(:member, description: 'A new description')
+      end
+
+      it 'updates the requested member' do
+        member = create(:member)
+        put api_v1_member_path(member),
+            params: { member: new_attributes }, headers: valid_headers, as: :json
+        member.reload
+      end
+
+      it 'renders a JSON response with the member' do
+        member = create(:member)
+        put api_v1_member_path(member),
+            params: { member: new_attributes }, headers: valid_headers, as: :json
+        expect(response).to have_http_status(:ok)
+        expect(response.content_type).to match(a_string_including('application/json; charset=utf-8'))
+      end
+    end
+
+    context 'with invalid parameters' do
+      it 'renders a JSON response with errors for the member' do
+        member = create(:member, name: 123_456)
+        put api_v1_member_path(member),
+            params: invalid_attributes, headers: valid_headers, as: :json
+        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response.content_type).to eq('application/json; charset=utf-8')
+      end
+    end
+  end
+
+  describe 'DELETE /destroy' do
+    let!(:member) { create(:member) }
+
+    it 'destroys the requested member' do
+      expect do
+        delete api_v1_member_path(member), headers: valid_headers, as: :json
+      end.to change(Member, :discarded)
+      expect(response).to have_http_status(:no_content)
+    end
   end
 end


### PR DESCRIPTION
COMO desarrollador
QUIERO disponer de tests de los endpoints de /members
PARA asegurar la integridad y funcionamiento del proyecto

Criterios de aceptación:
Testear el escenario de respuesta correcta, y escenarios de error, como ids inexistentes, validaciones, permisos, etc. El archivo deberá crearse dentro de la carpeta /test, con el mismo nombre del endpoint. Se puede utilizar como base el test creado a modo de demostración.