### PR TITLE
Ot260 88 Add documentation categories

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -73,3 +73,7 @@ RSpec/VariableName:
 NestedGroups:
   Exclude:
       - spec/**/*
+
+RSpec/EmptyExampleGroup:
+  Exclude:
+  - spec/integration/categories_spec.rb

--- a/app/controllers/api/v1/categories_controller.rb
+++ b/app/controllers/api/v1/categories_controller.rb
@@ -17,7 +17,7 @@ module Api
       end
 
       def show
-        render json: CategoriesSerializer.new(@categories).serializable_hash, status: :ok
+        render json: CategorySerializer.new(@category).serializable_hash, status: :ok
       end
 
       def create
@@ -34,8 +34,11 @@ module Api
       end
 
       def update
-        @category.update(category_params)
-        render json: CategorySerializer.new(@category).serializable_hash, status: :ok
+        if @category.update(category_params)
+          render json: CategorySerializer.new(@category).serializable_hash, status: :ok
+        else
+          render json: { error: 'Name parameter is not a Sting' }, status: :unprocessable_entity
+        end
       end
 
       def destroy

--- a/app/controllers/api/v1/news_controller.rb
+++ b/app/controllers/api/v1/news_controller.rb
@@ -10,7 +10,7 @@ module Api
       include Pagy::Backend
 
       def index
-        @pagy, @news = pagy(Category.kept)
+        @pagy, @news = pagy(News.kept)
         render json: NewsSerializer.new(@news).serializable_hash, status: :ok
       end
 

--- a/app/controllers/api/v1/organizations_controller.rb
+++ b/app/controllers/api/v1/organizations_controller.rb
@@ -18,6 +18,7 @@ module Api
                                                   facebook_url
                                                   instagram_url
                                                   linkedin_url
+                                                  slides
                                                 ] })
                                            .serializable_hash, status: :ok
       end

--- a/app/serializers/category_serializer.rb
+++ b/app/serializers/category_serializer.rb
@@ -22,4 +22,5 @@ class CategorySerializer
   attributes :image do |category|
     category.image.service_url if category.image.attached?
   end
+  has_many :news
 end

--- a/app/serializers/organization_serializer.rb
+++ b/app/serializers/organization_serializer.rb
@@ -30,4 +30,7 @@ class OrganizationSerializer
   attributes :image do |organization|
     organization.image.service_url if organization.image.attached?
   end
+  has_many :slides do |organization|
+    organization.slides.order(order: :asc)
+  end
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -24,7 +24,8 @@ module OT260Server
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 6.1
 
-   
+    # Set spanish as a default language
+    config.i18n.default_locale = :en
 
     # Configuration for the application, engines, and railties goes here.
     #

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -7,6 +7,9 @@ require "active_support/core_ext/integer/time"
 
 Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
+  #config.hosts << 'http://localhost:3000'
+  #Rails.application.default_url_options = {:host => 'http://localhost:3000' }
+  #Rails.application.routes.default_url_options = {:host => 'http://localhost:3000' }
 
   config.cache_classes = false
   config.action_view.cache_template_loading = true

--- a/spec/factories/categories.rb
+++ b/spec/factories/categories.rb
@@ -19,5 +19,7 @@ FactoryBot.define do
   factory :category do
     name { "Category #{rand(1..20)}" }
     description { Faker::Lorem.paragraph(sentence_count: 2) }
+
+    association :news
   end
 end

--- a/spec/factories/categories.rb
+++ b/spec/factories/categories.rb
@@ -17,7 +17,7 @@
 #
 FactoryBot.define do
   factory :category do
-    name { 'MyString' }
-    description { 'MyString' }
+    name { "Category #{rand(1..20)}" }
+    description { Faker::Lorem.paragraph(sentence_count: 2) }
   end
 end

--- a/spec/factories/news.rb
+++ b/spec/factories/news.rb
@@ -28,6 +28,7 @@ FactoryBot.define do
     image { 'MyString' }
     name { 'MyString' }
     news_type { 'news' }
-    category { nil }
+    
+    association :category
   end
 end

--- a/spec/integration/categories_spec.rb
+++ b/spec/integration/categories_spec.rb
@@ -1,0 +1,101 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'swagger_helper'
+
+RSpec.describe 'api/v1/categories', type: :request do
+  path '/api/v1/categories' do
+    
+    get('list categories') do
+      response(200, 'succesful') do
+
+        after do |example|
+          example.metadata[:response][:content] = {
+            'application/json' => {
+              example: JSON.parse(response.body, symbolize_names: true)
+            }
+          }
+        end
+        run_test!
+      end
+    end
+
+    post('create category') do
+      response(200, 'succesful') do
+        
+        after do |example|
+          example.metadata[:response][:content] = {
+            'application/json' => {
+              example: JSON.parse(response.body, symbolize_names: true)
+            }
+          }
+        end
+        run_test!
+      end
+    end
+  end
+
+  path 'api/v1/categories/{id}' do
+    parameter name: 'id', in: :path, type: :string, description: 'id'
+
+    get('show category') do
+      response(200, 'succesful') do
+        let(:id) { '123' }
+
+        after do |example|
+          example.metadata[:response][:content] = {
+            'application/json' => {
+              example: JSON.parse(response.body, symbolize_names: true)
+            }
+          }
+        end
+        run_test!
+      end
+    end
+
+    patch('update category') do
+      response(200, 'succesful') do
+        let(:id) { '123' }
+
+        after do |example|
+          example.metadata[:response][:content] = {
+            'application/json' => {
+              example: JSON.parse(response.body, symbolize_names: true)
+            }
+          }
+        end
+        run_test!
+      end
+    end
+
+    put('update category') do
+      response(200, 'succesful') do
+        let(:id) { '123' }
+
+        after do |example|
+          example.metadata[:response][:content] = {
+            'application/json' => {
+              example: JSON.parse(response.body, symbolize_names: true)
+            }
+          }
+        end
+        run_test!
+      end
+    end
+
+    delete('delete category') do
+      response(200, 'succesful') do
+        let(:id) { '123' }
+
+        after do |example|
+          example.metadata[:response][:content] = {
+            'application/json' => {
+              example: JSON.parse(response.body, symbolize_names: true)
+            }
+          }
+        end
+        run_test!
+      end
+    end
+  end
+end

--- a/spec/models/category_spec.rb
+++ b/spec/models/category_spec.rb
@@ -18,5 +18,26 @@
 require 'rails_helper'
 
 RSpec.describe Category, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  subject { create(:category) }
+  
+  describe 'Factory' do
+    it { is_expected.to be_valid }
+  end
+
+  describe 'Validations' do
+    it { is_expected.to validate_presence_of(:name) }
+  end
+
+  describe 'Database' do
+    it { is_expected.to have_db_column(:id).of_type(:integer).with_options(null: false) }
+    it { is_expected.to have_db_column(:name).of_type(:string).with_options(null: false) }
+    it { is_expected.to have_db_column(:description).of_type(:string) }
+    it { is_expected.to have_db_column(:discarded_at).of_type(:datetime) }
+    it { is_expected.to have_db_column(:created_at).of_type(:datetime).with_options(null: false) }
+    it { is_expected.to have_db_column(:updated_at).of_type(:datetime).with_options(null: false) }
+  end
+
+  describe 'Indexes' do
+    it { is_expected.to have_db_index(:discarded_at) }
+  end
 end

--- a/spec/models/category_spec.rb
+++ b/spec/models/category_spec.rb
@@ -19,7 +19,7 @@ require 'rails_helper'
 
 RSpec.describe Category, type: :model do
   subject { create(:category) }
-  
+
   describe 'Factory' do
     it { is_expected.to be_valid }
   end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -3,8 +3,6 @@
 # This file is copied to spec/ when you run 'rails generate rspec:install'
 require 'spec_helper'
 
-require 'shoulda-matchers'
-
 ENV['RAILS_ENV'] ||= 'test'
 require File.expand_path('../config/environment', __dir__)
 # Prevent database truncation if the environment is production

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -2,7 +2,9 @@
 
 # This file is copied to spec/ when you run 'rails generate rspec:install'
 require 'spec_helper'
+
 require 'shoulda-matchers'
+
 ENV['RAILS_ENV'] ||= 'test'
 require File.expand_path('../config/environment', __dir__)
 # Prevent database truncation if the environment is production

--- a/spec/requests/api/v1/categories_spec.rb
+++ b/spec/requests/api/v1/categories_spec.rb
@@ -1,34 +1,29 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
-RSpec.describe 'Api::V1::api_v1_Categories', type: :request do
-
-  before do
-    ENV['JWT_SECRET_KEY'] = 'secret'
-  end
-  
-  let!(:user) {  create(:user, email: 'fernando@gmail.com', password: 'password') }
+RSpec.describe 'Api::V1::Categories', type: :request do
   let(:login_user) do
-    #create(:user, password: 'password')
-    post api_v1_auth_login_url,
-      params: { user: { email: User.last.email, password: 'password' } }, as: :json
-    respond_has = JSON.parse(response.body, symbolize_names: true)
+    create(:user, password: 'password')
+    post api_v1_auth_login_path,
+         params: { user: { email: User.last.email, password: 'password' } }, as: :json
+    JSON.parse(response.body, symbolize_names: true)
   end
 
   let(:valid_headers) { { Authorization: login_user[:token] } }
   let(:valid_attributes) { build(:category) }
-  let(:invalid_attributes) { build(:category, name: 123_456) }
-  let(:categories) { Category.kept }
+  let(:invalid_attributes) { build(:category, name: '') }
 
   describe 'GET /index' do
-    before { create_list :category, 3}
+    before { create_list :category, 3 }
 
-    it 'renders a succesful response' do
-      get '/api/v1/categories', headers: valid_headers, as: :json
-      expect(response).to be_succesful  
+    it 'renders a successful response' do
+      get api_v1_categories_path, headers: valid_headers, as: :json
+      expect(response).to be_successful
     end
 
     it 'renders three registers from database' do
-      get '/api/v1/categories', headers: valid_headers, as: :json
+      get api_v1_categories_path, headers: valid_headers, as: :json
       response_hash = JSON.parse(response.body, symbolize_names: true)
       expect(response_hash[:data].size).to eq(Category.all.size)
     end
@@ -37,8 +32,8 @@ RSpec.describe 'Api::V1::api_v1_Categories', type: :request do
   describe 'GET /show' do
     it 'renders a succesful response' do
       category = create(:category)
-      get api_v1_categories_url(category), as: :json
-      expect(response).to be_succesful
+      get api_v1_categories_path(category), headers: valid_headers, as: :json
+      expect(response).to be_successful
     end
   end
 
@@ -46,32 +41,31 @@ RSpec.describe 'Api::V1::api_v1_Categories', type: :request do
     context 'with valid parameters' do
       it 'creates a new category' do
         expect do
-          post api_v1_categories_url,
-               params: { category: valid_attributes }, headers: valid_headers, as: :json
-        end.to change(categories, :count).by(1)
+          post api_v1_categories_path, params: valid_attributes, headers: valid_headers, as: :json
+        end.to change(Category, :count).by(1)
       end
 
       it 'renders a JSON response with the new category' do
-        post api_v1_categories_url,
-             params: { category: valid_attributes }, headers: valid_headers, as: :json
+        post api_v1_categories_path,
+             params: valid_attributes, headers: valid_headers, as: :json
         expect(response).to have_http_status(:created)
-        expect(response.content_type).to match(a_string_including('application/json'))
+        expect(response.content_type).to match(a_string_including('application/json; charset=utf-8'))
       end
     end
 
     context 'with invalid parameters' do
       it 'does not create a new category' do
         expect do
-          post api_v1_categories_url,
+          post api_v1_categories_path,
                params: { category: invalid_attributes }, as: :json
-        end.not_to change(categories, :count)
+        end.not_to change(Category, :count)
       end
 
       it 'renders a JSON response with errors for the new category' do
-        post api_v1_categories_url,
+        post api_v1_categories_path,
              params: { category: invalid_attributes }, headers: valid_headers, as: :json
         expect(response).to have_http_status(:unprocessable_entity)
-        expect(response.content_type).to eq('application/json')
+        expect(response.content_type).to eq('application/json; charset=utf-8')
       end
     end
   end
@@ -79,33 +73,34 @@ RSpec.describe 'Api::V1::api_v1_Categories', type: :request do
   describe 'PATCH /update' do
     context 'with valid parameters' do
       let(:new_attributes) do
-        build(:category, description: 'A new description')
+        { description: 'A new description' }
       end
 
       it 'updates the requested category' do
         category = create(:category)
-        patch api_v1_category_url(category),
-          params: { category: new_attributes }, headers: valid_headers, as: :json
-        category.reload
-        skip('Add assertions for updated state')
+        patch api_v1_category_path(category),
+              params: { category: new_attributes }, headers: valid_headers, as: :json
+        # category.reload
+        # skip('Add assertions for updated state')
+        expect(response).to have_http_status(:ok)
       end
 
       it 'renders a JSON response with the category' do
         category = create(:category)
-        patch category_url(category),
-          params: { category: new_attributes }, headers: valid_headers, as: :json
-        expect(response).to have_http_status(:ok)
-        expect(response.content_type).to match(a_string_including('application/json'))    
+        patch api_v1_category_path(category),
+              params: { category: new_attributes }, headers: valid_headers, as: :json
+        # expect(response).to have_http_status(:ok)
+        expect(response.content_type).to match(a_string_including('application/json; charset=utf-8'))
       end
     end
 
     context 'with invalid parameters' do
       it 'renders a JSON response with errors for the category' do
         category = create(:category)
-        patch category_url(category),
-          params: { category: invalid_attributes }, headers: valid_headers, as: :json
-        expect(response).to have_hhtp_status(:unprocessable_entity)
-        expect(response.content_type).to match(a_string_including('application/json'))    
+        patch api_v1_category_path(category),
+              params: { category: invalid_attributes }, headers: valid_headers, as: :json
+        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response.content_type).to eq('application/json; charset=utf-8')
       end
     end
   end
@@ -114,8 +109,9 @@ RSpec.describe 'Api::V1::api_v1_Categories', type: :request do
     it 'destroys the requested category' do
       category = create(:category)
       expect do
-          delete category_url(category), headers: valid_headers, as: :json
-      end.to change(category, :count).by(-1)
+        delete api_v1_category_path(category), headers: valid_headers, as: :json
+      end.to change(Category, :discarded)
+      expect(response).to have_http_status(:no_content)
     end
   end
 end

--- a/spec/requests/api/v1/categories_spec.rb
+++ b/spec/requests/api/v1/categories_spec.rb
@@ -1,9 +1,121 @@
-# frozen_string_literal: true
-
 require 'rails_helper'
 
-RSpec.describe 'Api::V1::Categories', type: :request do
+RSpec.describe 'Api::V1::api_v1_Categories', type: :request do
+
+  before do
+    ENV['JWT_SECRET_KEY'] = 'secret'
+  end
+  
+  let!(:user) {  create(:user, email: 'fernando@gmail.com', password: 'password') }
+  let(:login_user) do
+    #create(:user, password: 'password')
+    post api_v1_auth_login_url,
+      params: { user: { email: User.last.email, password: 'password' } }, as: :json
+    respond_has = JSON.parse(response.body, symbolize_names: true)
+  end
+
+  let(:valid_headers) { { Authorization: login_user[:token] } }
+  let(:valid_attributes) { build(:category) }
+  let(:invalid_attributes) { build(:category, name: 123_456) }
+  let(:categories) { Category.kept }
+
   describe 'GET /index' do
-    pending "add some examples (or delete) #{__FILE__}"
+    before { create_list :category, 3}
+
+    it 'renders a succesful response' do
+      get '/api/v1/categories', headers: valid_headers, as: :json
+      expect(response).to be_succesful  
+    end
+
+    it 'renders three registers from database' do
+      get '/api/v1/categories', headers: valid_headers, as: :json
+      response_hash = JSON.parse(response.body, symbolize_names: true)
+      expect(response_hash[:data].size).to eq(Category.all.size)
+    end
+  end
+
+  describe 'GET /show' do
+    it 'renders a succesful response' do
+      category = create(:category)
+      get api_v1_categories_url(category), as: :json
+      expect(response).to be_succesful
+    end
+  end
+
+  describe 'POST /create' do
+    context 'with valid parameters' do
+      it 'creates a new category' do
+        expect do
+          post api_v1_categories_url,
+               params: { category: valid_attributes }, headers: valid_headers, as: :json
+        end.to change(categories, :count).by(1)
+      end
+
+      it 'renders a JSON response with the new category' do
+        post api_v1_categories_url,
+             params: { category: valid_attributes }, headers: valid_headers, as: :json
+        expect(response).to have_http_status(:created)
+        expect(response.content_type).to match(a_string_including('application/json'))
+      end
+    end
+
+    context 'with invalid parameters' do
+      it 'does not create a new category' do
+        expect do
+          post api_v1_categories_url,
+               params: { category: invalid_attributes }, as: :json
+        end.not_to change(categories, :count)
+      end
+
+      it 'renders a JSON response with errors for the new category' do
+        post api_v1_categories_url,
+             params: { category: invalid_attributes }, headers: valid_headers, as: :json
+        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response.content_type).to eq('application/json')
+      end
+    end
+  end
+
+  describe 'PATCH /update' do
+    context 'with valid parameters' do
+      let(:new_attributes) do
+        build(:category, description: 'A new description')
+      end
+
+      it 'updates the requested category' do
+        category = create(:category)
+        patch api_v1_category_url(category),
+          params: { category: new_attributes }, headers: valid_headers, as: :json
+        category.reload
+        skip('Add assertions for updated state')
+      end
+
+      it 'renders a JSON response with the category' do
+        category = create(:category)
+        patch category_url(category),
+          params: { category: new_attributes }, headers: valid_headers, as: :json
+        expect(response).to have_http_status(:ok)
+        expect(response.content_type).to match(a_string_including('application/json'))    
+      end
+    end
+
+    context 'with invalid parameters' do
+      it 'renders a JSON response with errors for the category' do
+        category = create(:category)
+        patch category_url(category),
+          params: { category: invalid_attributes }, headers: valid_headers, as: :json
+        expect(response).to have_hhtp_status(:unprocessable_entity)
+        expect(response.content_type).to match(a_string_including('application/json'))    
+      end
+    end
+  end
+
+  describe 'DELETE /destroy' do
+    it 'destroys the requested category' do
+      category = create(:category)
+      expect do
+          delete category_url(category), headers: valid_headers, as: :json
+      end.to change(category, :count).by(-1)
+    end
   end
 end

--- a/swagger/api/v1/docs/swagger.yaml
+++ b/swagger/api/v1/docs/swagger.yaml
@@ -1,7 +1,7 @@
 ---
 openapi: 3.0.1
 info:
-  title: OT-260 API
+  title: API V1
   version: v1
   description: Alkemy OT-260 Ruby API Documentation.
 paths:
@@ -428,7 +428,7 @@ paths:
         '200':
           description: deleted successfully
 servers:
-- url: http://{defaultHost}
+- url: https://{defaultHost}
   variables:
     defaultHost:
       default: 127.0.0.1:3000/

--- a/swagger/api/v1/docs/swagger.yaml
+++ b/swagger/api/v1/docs/swagger.yaml
@@ -1,10 +1,123 @@
 ---
 openapi: 3.0.1
 info:
-  title: API V1
+  title: OT-260 API
   version: v1
   description: Alkemy OT-260 Ruby API Documentation.
 paths:
+  "/api/v1/categories":
+    get:
+      summary: Get All Categories
+      tags:
+      - Categories
+      security:
+      - Bearer: {}
+      parameters:
+      - name: Authorization
+        in: header
+        schema:
+          type: string
+      responses:
+        '200':
+          description: successful
+    post:
+      summary: Create Category
+      tags:
+      - Categories
+      security:
+      - Bearer: {}
+      parameters:
+      - name: Authorization
+        in: header
+        schema:
+          type: string
+      responses:
+        '201':
+          description: created
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                name:
+                  type: string
+                description:
+                  type: string
+                  nullable: true
+              required:
+              - name
+  "/api/v1/categories/{id}":
+    get:
+      summary: Show Category
+      tags:
+      - Categories
+      security:
+      - Bearer: {}
+      parameters:
+      - name: Authorization
+        in: header
+        schema:
+          type: string
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: string
+      responses:
+        '200':
+          description: got category
+    patch:
+      summary: Update Category
+      tags:
+      - Categories
+      security:
+      - Bearer: {}
+      parameters:
+      - name: Authorization
+        in: header
+        schema:
+          type: string
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: string
+      responses:
+        '200':
+          description: updated successfully
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                name:
+                  type: string
+                description:
+                  type: string
+                  nullable: true
+              required:
+              - name
+    delete:
+      summary: Delete Category
+      tags:
+      - Categories
+      security:
+      - Bearer: {}
+      parameters:
+      - name: Authorization
+        in: header
+        schema:
+          type: string
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: string
+      responses:
+        '200':
+          description: deleted successfully
   "/api/v1/members":
     get:
       summary: Get All Members
@@ -428,10 +541,10 @@ paths:
         '200':
           description: deleted successfully
 servers:
-- url: https://{defaultHost}
+- url: http://{defaultHost}
   variables:
     defaultHost:
-      default: 127.0.0.1:3000/
+      default: localhost:3000
 components:
   securitySchemes:
     Bearer:


### PR DESCRIPTION
Agregué el archivo de test y en la terminal ejecuta sin problemas pero aquí en el repo no pasa los tests.
![image](https://user-images.githubusercontent.com/65079282/183706545-48c756f7-f669-48ca-be97-5c1f1a5ab833.png)

También agregué la parte de swagger para documentación y se genera correctamente.
Aproveché a solucionar algunos problemas que tuve al verificar los endpoints:
1. Renombré el CategorySerializer en categories_controller.
2. Cambié el modelo Category por Testimonial en index del testimonials_controller.
3. Agregué el ordenamiento de slides en organization_serializer.
[OT260-88](https://alkemy-labs.atlassian.net/browse/OT260-88)
[OT260-101](https://alkemy-labs.atlassian.net/browse/OT260-101)