### PR TITLE
feat/OT-260-90-add-members-documentation

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -53,3 +53,19 @@ MultipleExpectations:
 MultipleMemoizedHelpers:
   Exclude:
     - spec/**/*
+
+ScatteredSetup:
+  Exclude:
+      - spec/**/*
+
+EmptyExampleGroup:
+  Exclude:
+      - spec/**/*
+
+DescribeClass:
+  Exclude:
+      - spec/**/*
+
+RSpec/VariableName:
+  Exclude:
+      - spec/**/*

--- a/app/controllers/api/v1/members_controller.rb
+++ b/app/controllers/api/v1/members_controller.rb
@@ -23,7 +23,7 @@ module Api
             render json: @member.errors, status: :unprocessable_entity
           end
         else
-          render json: { error: 'Name parameter is not a Sting' }, status: :unprocessable_entity
+          render json: { error: 'Name parameter is not a String' }, status: :unprocessable_entity
         end
       end
 
@@ -41,7 +41,7 @@ module Api
 
       def destroy
         @member.discard
-        head :no_content
+        head :ok
       end
 
       private

--- a/config/initializers/cors.rb
+++ b/config/initializers/cors.rb
@@ -5,12 +5,12 @@
 
 # Read more: https://github.com/cyu/rack-cors
 
-# Rails.application.config.middleware.insert_before 0, Rack::Cors do
-#   allow do
-#     origins 'example.com'
-#
-#     resource '*',
-#       headers: :any,
-#       methods: [:get, :post, :put, :patch, :delete, :options, :head]
-#   end
-# end
+Rails.application.config.middleware.insert_before 0, Rack::Cors do
+  allow do
+    origins '*'
+
+    resource '*',
+      headers: :any,
+      methods: [:get, :post, :put, :patch, :delete, :options, :head]
+  end
+end

--- a/spec/integration/members_spec.rb
+++ b/spec/integration/members_spec.rb
@@ -1,0 +1,138 @@
+# frozen_string_literal: true
+
+# spec/integration/blogs_spec.rb
+require 'swagger_helper'
+
+describe 'Members API' do
+  let(:login_user) do
+    create(:user, password: 'password')
+    post api_v1_auth_login_path,
+         params: { user: { email: User.last.email, password: 'password' } }, as: :json
+    JSON.parse(response.body, symbolize_names: true)
+  end
+
+  let(:Authorization) { login_user[:token] }
+
+  let(:member) { create(:member) }
+
+  path '/api/v1/members' do
+    get('Get All Members') do
+      response(200, 'successful') do
+        tags 'Members'
+        consumes 'application/json'
+        security [Bearer: {}]
+        parameter name: :Authorization, in: :header, type: :string
+        schema type: :object,
+               properties: {
+                 members: {
+                   type: :array,
+                   items: {
+                     properties: {
+                       id: { type: :integer },
+                       name: { type: :string },
+                       facebook_url: { type: :string, nullable: true },
+                       linkedin_url: { type: :string, nullable: true },
+                       instagram_url: { type: :string, nullable: true },
+                       description: { type: :string, nullable: true }
+                     }
+                   }
+                 }
+               }
+
+        after do |example|
+          example.metadata[:response][:content] = {
+            'application/json' => {
+              example: JSON.parse(response.body, symbolize_names: true)
+            }
+          }
+        end
+
+        run_test!
+      end
+    end
+
+    post('Create Member') do
+      response(201, 'created') do
+        tags 'Members'
+        consumes 'application/json'
+        security [Bearer: {}]
+        parameter name: :Authorization, in: :header, type: :string
+        parameter name: :member, in: :body, schema: {
+          type: :object,
+          properties: {
+            name: { type: :string },
+            facebook_url: { type: :string, nullable: true },
+            linkedin_url: { type: :string, nullable: true },
+            instagram_url: { type: :string, nullable: true },
+            description: { type: :string, nullable: true }
+          },
+          required: %w[name]
+        }
+        after do |example|
+          example.metadata[:response][:content] = {
+            'application/json' => {
+              example: JSON.parse(response.body, symbolize_names: true)
+            }
+          }
+        end
+
+        run_test!
+      end
+    end
+  end
+
+  path '/api/v1/members/{id}' do
+    put('Update Member') do
+      response(200, 'updated successfully') do
+        let(:id) { '123' }
+        tags 'Members'
+        consumes 'application/json'
+        security [Bearer: {}]
+        parameter name: :Authorization, in: :header, type: :string
+        parameter name: :id, in: :path, type: :string
+        parameter name: :member, in: :body, schema: {
+          type: :object,
+          properties: {
+            name: { type: :string },
+            facebook_url: { type: :string, nullable: true },
+            linkedin_url: { type: :string, nullable: true },
+            instagram_url: { type: :string, nullable: true },
+            description: { type: :string, nullable: true }
+          },
+          required: %w[name]
+        }
+
+        after do |example|
+          example.metadata[:response][:content] = {
+            'application/json' => {
+              example: JSON.parse(response.body, symbolize_names: true)
+            }
+          }
+        end
+
+        run_test!
+      end
+    end
+
+    delete('Delete Member') do
+      response(200, 'deleted successfully') do
+        let(:id) { '1' }
+        tags 'Members'
+        consumes 'application/json'
+        security [Bearer: {}]
+        parameter name: :Authorization, in: :header, type: :string
+        parameter name: :id, in: :path, type: :string
+
+        after do |example|
+          example.metadata[:response][:content] = {
+            'application/json' => {
+              example: JSON.parse(response.body, symbolize_names: true)
+            }
+          }
+        end
+
+        run_test!
+      end
+    end
+  end
+end

--- a/spec/requests/api/v1/members_spec.rb
+++ b/spec/requests/api/v1/members_spec.rb
@@ -104,7 +104,7 @@ RSpec.describe 'Api::V1::Members', type: :request do
       expect do
         delete api_v1_member_path(member), headers: valid_headers, as: :json
       end.to change(Member, :discarded)
-      expect(response).to have_http_status(:no_content)
+      expect(response).to have_http_status(:ok)
     end
   end
 end

--- a/spec/swagger_helper.rb
+++ b/spec/swagger_helper.rb
@@ -15,23 +15,33 @@ RSpec.configure do |config|
   # document below. You can override this behavior by adding a swagger_doc tag to the
   # the root example_group in your specs, e.g. describe '...', swagger_doc: 'v2/swagger.json'
   config.swagger_docs = {
-    'v1/swagger.yaml' => {
+    'api/v1/docs/swagger.yaml' => {
       openapi: '3.0.1',
       info: {
-        title: 'API V1',
-        version: 'v1'
+        title: 'OT-260 API',
+        version: 'v1',
+        description: 'Alkemy OT-260 Ruby API Documentation.'
       },
       paths: {},
       servers: [
         {
-          url: 'https://{defaultHost}',
+          url: 'http://{defaultHost}',
           variables: {
             defaultHost: {
               default: '127.0.0.1:3000/'
             }
           }
         }
-      ]
+      ],
+      components: {
+        securitySchemes: {
+          Bearer: {
+            type: :http,
+            scheme: :bearer,
+            name: 'Authorization'
+          }
+        }
+      }
     }
   }
 

--- a/swagger/api/v1/docs/swagger.yaml
+++ b/swagger/api/v1/docs/swagger.yaml
@@ -3,9 +3,128 @@ openapi: 3.0.1
 info:
   title: OT-260 API
   version: v1
-paths: {}
+  description: Alkemy OT-260 Ruby API Documentation.
+paths:
+  "/api/v1/members":
+    get:
+      summary: Get All Members
+      tags:
+      - Members
+      security:
+      - Bearer: {}
+      parameters:
+      - name: Authorization
+        in: header
+        schema:
+          type: string
+      responses:
+        '200':
+          description: successful
+    post:
+      summary: Create Member
+      tags:
+      - Members
+      security:
+      - Bearer: {}
+      parameters:
+      - name: Authorization
+        in: header
+        schema:
+          type: string
+      responses:
+        '201':
+          description: created
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                name:
+                  type: string
+                facebook_url:
+                  type: string
+                  nullable: true
+                linkedin_url:
+                  type: string
+                  nullable: true
+                instagram_url:
+                  type: string
+                  nullable: true
+                description:
+                  type: string
+                  nullable: true
+              required:
+              - name
+  "/api/v1/members/{id}":
+    put:
+      summary: Update Member
+      tags:
+      - Members
+      security:
+      - Bearer: {}
+      parameters:
+      - name: Authorization
+        in: header
+        schema:
+          type: string
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: string
+      responses:
+        '200':
+          description: updated successfully
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                name:
+                  type: string
+                facebook_url:
+                  type: string
+                  nullable: true
+                linkedin_url:
+                  type: string
+                  nullable: true
+                instagram_url:
+                  type: string
+                  nullable: true
+                description:
+                  type: string
+                  nullable: true
+              required:
+              - name
+    delete:
+      summary: Delete Member
+      tags:
+      - Members
+      security:
+      - Bearer: {}
+      parameters:
+      - name: Authorization
+        in: header
+        schema:
+          type: string
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: string
+      responses:
+        '200':
+          description: deleted successfully
 servers:
 - url: http://{defaultHost}
   variables:
     defaultHost:
-      default: 127.0.0.1:3000/api/v1/
+      default: 127.0.0.1:3000/
+components:
+  securitySchemes:
+    Bearer:
+      type: http
+      scheme: bearer
+      name: Authorization


### PR DESCRIPTION
COMO desarrollador
QUIERO disponer de una documentación de los endpoints de Miembros
PARA tener referencias de su funcionamiento

Criterios de aceptación:
Se deberán documentar los diferentes endpoints especificando el modelo de datos, campos obligatorios, formato de la petición y ejemplo de la misma.