### PR TITLE
Add documentation to testimonials

### DIFF
--- a/app/controllers/api/v1/testimonials_controller.rb
+++ b/app/controllers/api/v1/testimonials_controller.rb
@@ -38,6 +38,8 @@ module Api
 
       def set_testimonial
         @testimonial = Testimonial.kept.find(params[:id])
+      rescue ActiveRecord::RecordNotFound
+        render json: { error: "Could not find testimonial with ID '#{params[:id]}'" }
       end
 
       def testimonial_params

--- a/app/controllers/api/v1/testimonials_controller.rb
+++ b/app/controllers/api/v1/testimonials_controller.rb
@@ -10,7 +10,7 @@ module Api
       include Pagy::Backend
 
       def index
-        @pagy, @testimonials = pagy(Category.kept)
+        @pagy, @testimonials = pagy(Testimonial.kept)
         render json: TestimonialSerializer.new(@testimonials).serializable_hash, status: :ok
       end
 

--- a/spec/factories/testimonials.rb
+++ b/spec/factories/testimonials.rb
@@ -17,7 +17,7 @@
 #
 FactoryBot.define do
   factory :testimonial do
-    name { 'MyString' }
-    content { 'MyString' }
+    name { Faker::Name.first_name }
+    content { Faker::Lorem.paragraph }
   end
 end

--- a/spec/integration/testimonials_spec.rb
+++ b/spec/integration/testimonials_spec.rb
@@ -1,0 +1,132 @@
+# frozen_string_literal: true
+
+require 'swagger_helper'
+
+describe 'Testimonials API' do
+  let(:login_user) do
+    create(:user, password: 'password')
+    post api_v1_auth_login_path,
+         params: { user: { email: User.last.email, password: 'password' } }, as: :json
+    JSON.parse(response.body, symbolize_names: true)
+  end
+
+  let(:Authorization) { login_user[:token] }
+
+  let(:testimonial) { create(:testimonial) }
+
+  before do
+    ENV['JWT_SECRET_KEY'] = 'secret_key'
+  end
+
+  path '/api/v1/testimonials' do
+    get('Get All Testimonials') do
+      response(200, 'successful') do
+        tags 'Testimonials'
+        consumes 'application/json'
+        security [Bearer: {}]
+        parameter name: :Authorization, in: :header, type: :string
+        schema type: :object,
+               properties: {
+                 testimonials: {
+                   type: :array,
+                   items: {
+                     properties: {
+                       id: { type: :integer },
+                       name: { type: :string },
+                       content: { type: :string, nullable: true }
+                     }
+                   }
+                 }
+               }
+
+        after do |example|
+          example.metadata[:response][:content] = {
+            'application/json' => {
+              example: JSON.parse(response.body, symbolize_names: true)
+            }
+          }
+        end
+
+        run_test!
+      end
+    end
+
+    post('Create Testimonials') do
+      response(201, 'created') do
+        tags 'Testimonials'
+        consumes 'application/json'
+        security [Bearer: {}]
+        parameter name: :Authorization, in: :header, type: :string
+        parameter name: :testimonial, in: :body, schema: {
+          type: :object,
+          properties: {
+            name: { type: :string },
+            content: { type: :string, nullable: true }
+          },
+          required: %w[name]
+        }
+        after do |example|
+          example.metadata[:response][:content] = {
+            'application/json' => {
+              example: JSON.parse(response.body, symbolize_names: true)
+            }
+          }
+        end
+
+        run_test!
+      end
+    end
+  end
+
+  path '/api/v1/testimonials/{id}' do
+    patch('Update Testimonial') do
+      response(200, 'updated successfully') do
+        let(:id) { '123' }
+        tags 'Testimonials'
+        consumes 'application/json'
+        security [Bearer: {}]
+        parameter name: :Authorization, in: :header, type: :string
+        parameter name: :id, in: :path, type: :string
+        parameter name: :testimonial, in: :body, schema: {
+          type: :object,
+          properties: {
+            name: { type: :string },
+            content: { type: :string, nullable: true }
+          },
+          required: %w[name]
+        }
+
+        after do |example|
+          example.metadata[:response][:content] = {
+            'application/json' => {
+              example: JSON.parse(response.body, symbolize_names: true)
+            }
+          }
+        end
+
+        run_test!
+      end
+    end
+
+    delete('Delete Testimonial') do
+      response(200, 'deleted successfully') do
+        let(:id) { '1' }
+        tags 'Testimonials'
+        consumes 'application/json'
+        security [Bearer: {}]
+        parameter name: :Authorization, in: :header, type: :string
+        parameter name: :id, in: :path, type: :string
+
+        after do |example|
+          example.metadata[:response][:content] = {
+            'application/json' => {
+              example: JSON.parse(response.body, symbolize_names: true)
+            }
+          }
+        end
+
+        run_test!
+      end
+    end
+  end
+end

--- a/spec/integration/testimonials_spec.rb
+++ b/spec/integration/testimonials_spec.rb
@@ -14,10 +14,6 @@ describe 'Testimonials API' do
 
   let(:testimonial) { create(:testimonial) }
 
-  before do
-    ENV['JWT_SECRET_KEY'] = 'secret_key'
-  end
-
   path '/api/v1/testimonials' do
     get('Get All Testimonials') do
       response(200, 'successful') do

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -2,6 +2,7 @@
 
 # This file is copied to spec/ when you run 'rails generate rspec:install'
 require 'spec_helper'
+require 'shoulda-matchers'
 ENV['RAILS_ENV'] ||= 'test'
 require File.expand_path('../config/environment', __dir__)
 # Prevent database truncation if the environment is production

--- a/spec/swagger_helper.rb
+++ b/spec/swagger_helper.rb
@@ -28,7 +28,7 @@ RSpec.configure do |config|
           url: 'http://{defaultHost}',
           variables: {
             defaultHost: {
-              default: '127.0.0.1:3000/'
+              default: 'localhost:3000'
             }
           }
         }

--- a/swagger/api/v1/docs/swagger.yaml
+++ b/swagger/api/v1/docs/swagger.yaml
@@ -333,6 +333,100 @@ paths:
                   type: text
               required:
               - name
+               "/api/v1/testimonials":
+    get:
+      summary: Get All Testimonials
+      tags:
+      - Testimonials
+      security:
+      - Bearer: {}
+      parameters:
+      - name: Authorization
+        in: header
+        schema:
+          type: string
+      responses:
+        '200':
+          description: successful
+    post:
+      summary: Create Testimonials
+      tags:
+      - Testimonials
+      security:
+      - Bearer: {}
+      parameters:
+      - name: Authorization
+        in: header
+        schema:
+          type: string
+      responses:
+        '201':
+          description: created
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                name:
+                  type: string
+                content:
+                  type: string
+                  nullable: true
+              required:
+              - name
+  "/api/v1/testimonials/{id}":
+    patch:
+      summary: Update Testimonial
+      tags:
+      - Testimonials
+      security:
+      - Bearer: {}
+      parameters:
+      - name: Authorization
+        in: header
+        schema:
+          type: string
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: string
+      responses:
+        '200':
+          description: updated successfully
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                name:
+                  type: string
+                content:
+                  type: string
+                  nullable: true
+              required:
+              - name
+    delete:
+      summary: Delete Testimonial
+      tags:
+      - Testimonials
+      security:
+      - Bearer: {}
+      parameters:
+      - name: Authorization
+        in: header
+        schema:
+          type: string
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: string
+      responses:
+        '200':
+          description: deleted successfully
 servers:
 - url: http://{defaultHost}
   variables:


### PR DESCRIPTION
As a developer
I WANT to have a documentation of the endpoints of Testimonials
TO have references of its operation

The different endpoints must be documented specifying the data model, required fields, request format and example.

![image](https://user-images.githubusercontent.com/65079282/184253815-81ccce52-1281-4a72-a58f-78ee5ea857f2.png)
![image](https://user-images.githubusercontent.com/65079282/184253922-743b8715-2b00-4298-8968-4729945ac637.png)
![image](https://user-images.githubusercontent.com/65079282/184254161-414c1a05-1aef-487b-9ff6-b961de7d0f2e.png)
![image](https://user-images.githubusercontent.com/65079282/184254194-bbf34c4d-60f2-47b5-aa14-42d7ec620618.png)
![image](https://user-images.githubusercontent.com/65079282/184254207-d1fcf313-7ac0-4182-9608-3be0845ab160.png)

[OT260-91](https://alkemy-labs.atlassian.net/browse/OT260-91)