### PR TITLE
OT260-103-Agregar-Documentación-a-News

### DIFF
--- a/spec/factories/news.rb
+++ b/spec/factories/news.rb
@@ -28,6 +28,21 @@ FactoryBot.define do
     image { 'MyString' }
     name { 'MyString' }
     news_type { 'news' }
-    category { nil }
+    category { create(:category) }
+
+    trait :good do
+      name { Faker::Lorem.sentence }
+      content { Faker::Lorem.paragraph }
+      image { Faker::Lorem.sentence }
+    end
+
+    trait :bad do
+      name { nil }
+      content { nil }
+      image { nil }
+    end
+
+    factory :good_news, traits: [:good]
+    factory :bad_news, traits: [:bad]
   end
 end

--- a/spec/requests/api/v1/news/create_spec.rb
+++ b/spec/requests/api/v1/news/create_spec.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'News', type: :request do
+  let(:user) { create(:normal_user) }
+  let(:user_id) { user.id }
+  let(:token) { Authenticable.encode(user_id: user_id) }
+
+  describe 'POST /news without Auth Token' do
+    it 'returns Unauthorized without Token' do
+      news = build(:good_news)
+      post '/news', params: { news: news.attributes }
+      # :unauthorized = 401
+      expect(response).to have_http_status(:unauthorized)
+    end
+  end
+
+  describe 'POST /news with Auth Token:' do
+    it 'returns unprocessable_entity with empty news' do
+      news = build(:bad_news)
+      post '/news', params: { news: news.attributes },
+                    headers: { 'Authorization' => "Bearer #{token}" },
+                    as: :json
+      # :unprocessable_entity = 422
+      expect(response).to have_http_status(:unprocessable_entity)
+    end
+
+    it 'with good data returns created' do
+      news = build(:good_news)
+      post '/news', params: { news: news.attributes },
+                    headers: { 'Authorization' => "Bearer #{token}" },
+                    as: :json
+      # :created = 201
+      expect(response).to have_http_status(:created)
+    end
+  end
+end

--- a/spec/requests/api/v1/news/destroy_spec.rb
+++ b/spec/requests/api/v1/news/destroy_spec.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'News', type: :request do
+  let(:news) { create(:good_news) }
+  let(:user) { create(:normal_user) }
+  let(:user_id) { user.id }
+  let(:token) { Authenticable.encode(user_id: user_id) }
+
+  describe 'DELETE /news/{id} without Token' do
+    it 'returns Unauthorized' do
+      delete "/news/#{news.id}"
+      # :unauthorized = 401
+      expect(response).to have_http_status(:unauthorized)
+    end
+  end
+
+  describe 'DELETE /news/{id} with Token' do
+    it 'delete successfully the news' do
+      delete "/news/#{news.id}", headers: { 'Authorization' => "Bearer #{token}" }
+      # :ok = 200
+      expect(response).to have_http_status(:ok)
+    end
+
+    it 'returns 404 not found' do
+      delete '/news/1000', headers: { 'Authorization' => "Bearer #{token}" }
+      # :not_found = 404
+      expect(response).to have_http_status(:not_found)
+    end
+  end
+end

--- a/spec/requests/api/v1/news/details_spec.rb
+++ b/spec/requests/api/v1/news/details_spec.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'News', type: :request do
+  let(:user) { create(:normal_user) }
+  let(:user_id) { user.id }
+  let(:token) { Authenticable.encode(user_id: user_id) }
+  let(:good_news) { create(:good_news) }
+  let(:bad_news) { create(:bad_news) }
+
+  describe 'GET /news/{id}/details Without Token' do
+    it 'returns http 401' do
+      get "/news/#{good_news.id}/details"
+      # unauthorized = 401
+      expect(response).to have_http_status(:unauthorized)
+    end
+  end
+
+  describe 'GET /news/{id}/details With Token' do
+    it 'respond with 200' do
+      get "/news/#{good_news.id}/details",
+          headers: { 'Authorization' => "Bearer #{token}" },
+          as: :json
+      # ok = 200
+      expect(response).to have_http_status(:ok)
+    end
+
+    it 'returns 404 not found' do
+      get '/news/1000/details', headers: { 'Authorization' => "Bearer #{token}" }
+      # not_found = 404
+      expect(response).to have_http_status(:not_found)
+    end
+  end
+end

--- a/spec/requests/api/v1/news_spec.rb
+++ b/spec/requests/api/v1/news_spec.rb
@@ -1,9 +1,74 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
+require 'swagger_helper'
 
-RSpec.describe 'Api::V1::News', type: :request do
-  describe 'GET /index' do
-    pending "add some examples (or delete) #{__FILE__}"
+RSpec.describe 'news', type: :request do
+  let(:user) { create(:normal_user) }
+  let(:user_id) { user.id }
+  let(:token) { Authenticable.encode(user_id: user_id) }
+  let(:good_news) { create(:good_news) }
+  let(:bad_news) { create(:bad_news) }
+
+  path '/news/{id}/details' do
+    # You'll want to customize the parameter types...
+    parameter name: 'id', in: :path, type: :string, description: 'id'
+
+    get('details news') do
+      tags 'News'
+      response(401, 'unauthorized') do
+        let(:id) { good_news.id }
+        run_test!
+      end
+      response(404, 'not found') do
+        run_test!
+      end
+      response(200, 'news found') do
+        run_test!
+      end
+    end
+  end
+
+  path '/news' do
+    post('create news') do
+      tags 'News'
+      response(201, 'news created') do
+        run_test!
+      end
+    end
+  end
+
+  path '/news/{id}' do
+    # You'll want to customize the parameter types...
+    parameter name: 'id', in: :path, type: :string, description: 'id'
+
+    put('update news') do
+      tags 'News'
+      response(401, 'unauthorized') do
+        run_test!
+      end
+      response(404, 'not found') do
+        run_test!
+      end
+      response(200, 'successful') do
+        run_test!
+      end
+    end
+
+    delete('delete news') do
+      parameter name: 'id', in: :path, type: :string, description: 'id'
+      tags 'News'
+      response(401, 'unauthorized') do
+        run_test!
+      end
+      response(200, 'successful') do
+        run_test!
+      end
+      response(404, 'not found') do
+        run_test!
+      end
+      response(422, 'unprocessable_entity') do
+        run_test!
+      end
+    end
   end
 end

--- a/swagger/api/v1/docs/swagger.yaml
+++ b/swagger/api/v1/docs/swagger.yaml
@@ -117,6 +117,72 @@ paths:
       responses:
         '200':
           description: deleted successfully
+  "/api/v1/news/{id}/details":
+    parameters:
+    - name: id
+      in: path
+      description: id
+      required: true
+      schema:
+        type: string
+    get:
+      summary: details news
+      tags:
+      - News
+      responses:
+        '401':
+          description: unauthorized
+        '404':
+          description: not found
+        '200':
+          description: news found
+  "/api/v1/news":
+    post:
+      summary: create news
+      tags:
+      - News
+      responses:
+        '201':
+          description: news created
+  "/api/v1/news/{id}":
+    parameters:
+    - name: id
+      in: path
+      description: id
+      required: true
+      schema:
+        type: string
+    put:
+      summary: update news
+      tags:
+      - News
+      responses:
+        '401':
+          description: unauthorized
+        '404':
+          description: not found
+        '200':
+          description: successful
+    delete:
+      summary: delete news
+      parameters:
+      - name: id
+        in: path
+        description: id
+        required: true
+        schema:
+          type: string
+      tags:
+      - News
+      responses:
+        '401':
+          description: unauthorized
+        '200':
+          description: successful
+        '404':
+          description: not found
+        '422':
+          description: unprocessable_entity        
 servers:
 - url: http://{defaultHost}
   variables:


### PR DESCRIPTION
COMO desarrollador
QUIERO disponer de tests de los endpoints de /news
PARA asegurar la integridad y funcionamiento del proyecto

Criterios de aceptación:
Testear el escenario de respuesta correcta, y escenarios de error, como ids inexistentes, validaciones, permisos, etc. El archivo deberá crearse dentro de la carpeta /test, con el mismo nombre del endpoint. Se puede utilizar como base el test creado a modo de demostración.
Ademas sumamos documentacion para news.